### PR TITLE
Disable Save Button after click on EDIT screeen

### DIFF
--- a/lib/jquery.jtable.js
+++ b/lib/jquery.jtable.js
@@ -2208,7 +2208,7 @@ THE SOFTWARE.
                                     return;
                                 }
 
-                                var $saveButton = self._$editDiv.find('#EditDialogSaveButton');
+                                var $saveButton = $('#EditDialogSaveButton');
                                 var $editForm = self._$editDiv.find('form');
                                 if (self._trigger("formSubmitting", null, { form: $editForm, formType: 'edit', row: self._$editingRow }) != false) {
                                     self._setEnabledOfDialogButton($saveButton, false, self.options.messages.saving);


### PR DESCRIPTION
There was issue while click on SAVE Button on EDIT screen it was not disabling the button.

Due to that user can click the save button multiple times.I debugged and found it was not getting save button object properly self._$editDiv.find('#EditDialogSaveButton');

-Amit
