### PR TITLE
New field type: formHidden

### DIFF
--- a/lib/jquery.jtable.js
+++ b/lib/jquery.jtable.js
@@ -2101,6 +2101,12 @@ THE SOFTWARE.
                     $addRecordForm.append(self._createInputForHidden(fieldName, field.defaultValue));
                     continue;
                 }
+                
+                //formHidden field
+                if (field.type == 'formHidden') {
+                    $editForm.append(self._createInputForHidden(fieldName, field.defaultValue));
+                    continue;
+                }
 
                 //Create a container div for this input field and add to form
                 var $fieldContainer = $('<div />')
@@ -2424,6 +2430,12 @@ THE SOFTWARE.
                     continue;
                 }
 
+                //formHidden field
+                if (field.type == 'formHidden') {
+                    $editForm.append(self._createInputForHidden(fieldName, fieldValue));
+                    continue;
+                }
+                
                 //Create a container div for this input field and add to form
                 var $fieldContainer = $('<div class="jtable-input-field-container"></div>').appendTo($editForm);
 


### PR DESCRIPTION
The code in @fb368f7 will recognize a new field type called formHidden which will allow users to show a field in the list, but hide in on the create/edit form and still pass the original value instead of NULL.   Here is an example field definition.

<pre>                Time_Stamp: {
                    title: 'Time_Stamp',
                    type: 'formHidden'
                },</pre>


Hope it helps!

Update: If you like formHidden, but need to independently hide on create or edit forms... check out jojozepp's <a href="https://github.com/hikalkan/jtable/pull/750">createHidden and editHidden code</a>.  It acts much the same as formHidden, except it lets you choose on which form your field is hidden.
