### PR TITLE
FEATURE Added Datepicker Year/Month Edit Option + allRows Public Method

### DIFF
--- a/dev/jquery.jtable.core.js
+++ b/dev/jquery.jtable.core.js
@@ -24,6 +24,8 @@
             fields: {},
             animationsEnabled: true,
             defaultDateFormat: 'yy-mm-dd',
+            defaultDateChangeYear: false,   /* Default: Let the year be modified in this jTable's create/edit calendar popup */
+            defaultDateChangeMonth: false,  /* Default: Let the month be modified in this jTable's create/edit calendar popup */
             dialogShowEffect: 'fade',
             dialogHideEffect: 'fade',
             showCloseButton: false,

--- a/dev/jquery.jtable.forms.js
+++ b/dev/jquery.jtable.forms.js
@@ -107,7 +107,9 @@
             }
             
             var displayFormat = field.displayFormat || this.options.defaultDateFormat;
-            $input.datepicker({ dateFormat: displayFormat });
+            /* changeYear and changeMonth are jQuery UI datepicker modal options ... make Year/Month optionally editable */
+            /* datepicker year and month are editable depending on options.defaultDateChangeYear, options.defaultDateChangeMonth */
+            $input.datepicker({ dateFormat: displayFormat, changeYear: this.options.defaultDateChangeYear, changeMonth: this.options.defaultDateChangeMonth });
             return $('<div />')
                 .addClass('jtable-input jtable-date-input')
                 .append($input);

--- a/dev/jquery.jtable.selecting.js
+++ b/dev/jquery.jtable.selecting.js
@@ -87,6 +87,12 @@
             return this._getSelectedRows();
         },
 
+        /* Gets jQuery selection for all rows.
+        *************************************************************************/
+        allRows: function() {
+            return this._getAllRows();
+        },
+
         /* Makes row/rows 'selected'.
         *************************************************************************/
         selectRows: function ($rows) {
@@ -236,6 +242,13 @@
         _getSelectedRows: function () {
             return this._$tableBody
                 .find('>tr.jtable-row-selected');
+        },
+
+        /* Gets all rows (selected or not).
+        *************************************************************************/
+        _getAllRows: function () {
+            return this._$tableBody
+                .find('>tr.jtable-data-row');
         },
 
         /* Adds selectable feature to a row.

--- a/lib/jquery.jtable.js
+++ b/lib/jquery.jtable.js
@@ -53,6 +53,8 @@ THE SOFTWARE.
             fields: {},
             animationsEnabled: true,
             defaultDateFormat: 'yy-mm-dd',
+            defaultDateChangeYear: false,   /* Default: Let the year be modified in this jTable's create/edit calendar popup */
+            defaultDateChangeMonth: false,  /* Default: Let the month be modified in this jTable's create/edit calendar popup */
             dialogShowEffect: 'fade',
             dialogHideEffect: 'fade',
             showCloseButton: false,
@@ -1523,7 +1525,9 @@ THE SOFTWARE.
             }
             
             var displayFormat = field.displayFormat || this.options.defaultDateFormat;
-            $input.datepicker({ dateFormat: displayFormat });
+            /* changeYear and changeMonth are jQuery UI datepicker modal options ... make Year/Month optionally editable */
+            /* datepicker year and month are editable depending on options.defaultDateChangeYear, options.defaultDateChangeMonth */
+            $input.datepicker({ dateFormat: displayFormat, changeYear: this.options.defaultDateChangeYear, changeMonth: this.options.defaultDateChangeMonth });
             return $('<div />')
                 .addClass('jtable-input jtable-date-input')
                 .append($input);
@@ -3091,6 +3095,12 @@ THE SOFTWARE.
             return this._getSelectedRows();
         },
 
+        /* Gets jQuery selection for all rows.
+        *************************************************************************/
+        allRows: function() {
+            return this._getAllRows();
+        },
+
         /* Makes row/rows 'selected'.
         *************************************************************************/
         selectRows: function ($rows) {
@@ -3240,6 +3250,13 @@ THE SOFTWARE.
         _getSelectedRows: function () {
             return this._$tableBody
                 .find('>tr.jtable-row-selected');
+        },
+
+        /* Gets all rows (selected or not).
+        *************************************************************************/
+        _getAllRows: function () {
+            return this._$tableBody
+                .find('>tr.jtable-data-row');
         },
 
         /* Adds selectable feature to a row.


### PR DESCRIPTION
Added feature to have default value in options so the user
can set whether the datepicker in jTable forms lets
the user directly change the month and the year. This is
done via options defaultDateChangeYear and 
defaultDateChangeMonth which by default are set to false, 
but either one or both can be set to true by the user 
during jTable initialization.  Doing so modifies the behavior
of the datepicker object in table create/edit forms, letting
the user optionally direct select the year and/or month 
(rather than having to scroll through time).

A second feature to allows the user to call public jTable.allRows(),
analogous to jTable.selectedRows().  In addition to just
returning the selected rows, we now return all the rows
in the jTable (and thus underlying data) by calling allRows().

Modified both the jquery.jtable.js source with these changes,
as well as the underlying dev source with identical changes.
