### PR TITLE
Allow users to specify a 'custom' type for a field, and run the display ...

### DIFF
--- a/dev/jquery.jtable.forms.js
+++ b/dev/jquery.jtable.forms.js
@@ -77,6 +77,13 @@
                 return this._createPasswordInputForField(field, fieldName, value);
             } else if (field.type == 'checkbox') {
                 return this._createCheckboxForField(field, fieldName, value);
+            } else if (field.type == 'custom') {
+                if (typeof field.display === 'function') {
+                    var $display = field.display();
+                    return $('<div />')
+                        .addClass('jtable-input jtable-input-custom')
+                        .append($display);
+                }
             } else if (field.options) {
                 if (field.type == 'radiobutton') {
                     return this._createRadioButtonListForField(field, fieldName, value, record, formType);


### PR DESCRIPTION
...function for that field when adding a new record.

My specific use case was to allow users to upload a file. By using this 'custom' field type, I can upload the file, modify the meta inside my record, and save everything appropriately.

``` javascript
    fields: {
            upload: {
                list: false,
                edit: false,
                type: 'custom',
                title: 'Upload File',
                display: function(data) {
                    var $fieldView = $('<div/>');
                    var $upload = $('<input />', {
                        'type': 'file',
                        'id': 'file_upload',
                        'name': 'files'
                    });
                    // This will be wrapped with the appropriate jtable divs
                    $fieldView.append($upload);

                    // When we receive the file info, this runs
                    $upload.bind('change', function() {
                        var s3upload = new S3Upload({
                            onFinishS3Put: function(url, signedResult) {
                                // Now that everything has finished, we can modify the Edit-url
                                // element, and when jtable saves the record, the correct url will be saved
                                $('#Edit-url').val(url);
                            }
                        });
                    });

                    return $fieldView;
                }
             }
        }
```
