### PR TITLE
Add params to personalize ajax requests

### DIFF
--- a/dev/jquery.jtable.paging.js
+++ b/dev/jquery.jtable.paging.js
@@ -29,6 +29,8 @@
             pageSizes: [10, 25, 50, 100, 250, 500],
             pageSizeChangeArea: true,
             gotoPageArea: 'combobox', //possible values: 'textbox', 'combobox', 'none'
+            pageSizeParam: 'jtPageSize',
+            startIndexParam: 'jtStartIndex',
 
             messages: {
                 pagingInfo: 'Showing {0}-{1} of {2}',
@@ -326,8 +328,8 @@
             var jtParams = base._createJtParamsForLoading.apply(this, arguments);
             
             if (this.options.paging) {
-                jtParams.jtStartIndex = (this._currentPageNo - 1) * this.options.pageSize;
-                jtParams.jtPageSize = this.options.pageSize;
+                jtParams[this.options.startIndexParam] = (this._currentPageNo - 1) * this.options.pageSize;
+                jtParams[this.options.pageSizeParam] = this.options.pageSize;
             }
 
             return jtParams;
@@ -388,7 +390,7 @@
         * PRIVATE METHODS                                                       *
         *************************************************************************/
 
-        /* Adds jtStartIndex and jtPageSize parameters to a URL as query string.
+        /* Adds startIndexParam and pageSizeParam parameters (old jtStartIndex and jtPageSize) to a URL as query string.
         *************************************************************************/
         _addPagingInfoToUrl: function (url, pageNumber) {
             if (!this.options.paging) {
@@ -398,7 +400,7 @@
             var jtStartIndex = (pageNumber - 1) * this.options.pageSize;
             var jtPageSize = this.options.pageSize;
 
-            return (url + (url.indexOf('?') < 0 ? '?' : '&') + 'jtStartIndex=' + jtStartIndex + '&jtPageSize=' + jtPageSize);
+            return (url + (url.indexOf('?') < 0 ? '?' : '&') + this.options.startIndexParam + '=' + jtStartIndex + '&' + this.options.pageSizeParam + '=' + jtPageSize);
         },
 
         /* Creates and shows the page list.

--- a/dev/jquery.jtable.sorting.js
+++ b/dev/jquery.jtable.sorting.js
@@ -21,7 +21,8 @@
         options: {
             sorting: false,
             multiSorting: false,
-            defaultSorting: ''
+            defaultSorting: '',
+            sortingParam: 'jtSorting'
         },
 
         /************************************************************************
@@ -165,7 +166,7 @@
             this._reloadTable();
         },
 
-        /* Adds jtSorting parameter to a URL as query string.
+        /* Adds sortingParam parameter (old jtSorting) to a URL as query string.
         *************************************************************************/
         _addSortingInfoToUrl: function (url) {
             if (!this.options.sorting || this._lastSorting.length == 0) {
@@ -177,7 +178,7 @@
                 sorting.push(value.fieldName + ' ' + value.sortOrder);
             });
 
-            return (url + (url.indexOf('?') < 0 ? '?' : '&') + 'jtSorting=' + sorting.join(","));
+            return (url + (url.indexOf('?') < 0 ? '?' : '&') + this.options.sortingParam + '=' + sorting.join(","));
         },
 
         /* Overrides _createJtParamsForLoading method to add sorging parameters to jtParams object.
@@ -191,7 +192,7 @@
                     sorting.push(value.fieldName + ' ' + value.sortOrder);
                 });
 
-                jtParams.jtSorting = sorting.join(",");
+                jtParams[this.options.sortingParam] = sorting.join(",");
             }
 
             return jtParams;


### PR DESCRIPTION
Add params to personalize ajax requests in paging:
- pageSizeParam: 'jtPageSize',
- startIndexParam: 'jtStartIndex'
  and sorting:
- sortingParam: 'jtSorting'

manteing default values original params
