### PR TITLE
Bug fix for checkboxes in form dialogues

### DIFF
--- a/lib/jquery.jtable.js
+++ b/lib/jquery.jtable.js
@@ -1691,7 +1691,6 @@ THE SOFTWARE.
             return $containerDiv;
         },
 
-
         /* Creates a drop down list (combobox) input element for a field.
         *************************************************************************/
         _createDropDownListForField: function (field, fieldName, value, record, source, form) {


### PR DESCRIPTION
This commit fixes a bug in form dialogues where the checkbox property is not actually toggled back a second time when using the label text. The issue is caused by the use of the `checked` attribute (`.attr('checked'`) because changing this attribute is not guarenteed to update the element `checked` property. Attached is an image proving how this can arise in an updated version of Chrome. See how the attribute is present but the property does not match. This was after clicking the `span` element a second time.

Using the `.prop` method of the jQuery we use fixes this issue totally. It is suggested other usage of `attr` on checkboxes is revised.

Proof:
![attr-checked-but-not-prop-proof](https://cloud.githubusercontent.com/assets/3536087/3131049/1cbb4fd8-e800-11e3-8a35-3b1cd244a56b.PNG)
