### PR TITLE
Add the currency field type

### DIFF
--- a/lib/jquery.jtable.js
+++ b/lib/jquery.jtable.js
@@ -741,7 +741,11 @@ THE SOFTWARE.
                 return this._getDisplayTextForDateRecordField(field, fieldValue);
             } else if (field.type == 'checkbox') {
                 return this._getCheckBoxTextForFieldByValue(fieldName, fieldValue);
-            } else if (field.options) { //combobox or radio button list since there are options.
+            } else if (field.type == 'currency') {
+                var curr = field.currencyType || '€';
+                var money = fieldValue || 0;
+                return curr + '' + money.toFixed(2);
+            }else if (field.options) { //combobox or radio button list since there are options.
                 var options = this._getOptionsForField(fieldName, {
                     record: record,
                     value: fieldValue,


### PR DESCRIPTION
Use case example:
field definition ... ,
Price: {
    title: 'Price',
    type: 'currency',
        currencyType: '$' // default €, if you don't need to change you can avoid to declare this
}

I needed to add this to my project. If you like you can update yours.
Cheers, 
Peter Boccia
