### PR TITLE
Column header tooltip

### DIFF
--- a/lib/jquery.jtable.js
+++ b/lib/jquery.jtable.js
@@ -326,6 +326,10 @@ THE SOFTWARE.
                 .data('fieldName', fieldName)
                 .append($headerContainerDiv);
 
+            if (field.tooltip) {
+              $th.prop('title', field.tooltip);
+            }
+
             this._jqueryuiThemeAddClass($th, 'ui-state-default');
 
             return $th;


### PR DESCRIPTION
In our project we'd like to be able to specify a tooltip for column header. In HTML this is simply the `title` attribute. In addition, libraries like jQuery UI will make this titles look very nice.

My change will make it possible to have a `tooltip` property on the column that will be simply added to the `<th>`'s `title` attribute.
