### PR TITLE
docs: Fix simple typo, comparision -> comparison

### DIFF
--- a/dev/jquery.jtable.utils.js
+++ b/dev/jquery.jtable.utils.js
@@ -37,11 +37,11 @@
             }
         },
 
-        /* Finds index of an element in an array according to given comparision function
+        /* Finds index of an element in an array according to given comparison function
         *************************************************************************/
         _findIndexInArray: function (value, array, compareFunc) {
 
-            //If not defined, use default comparision
+            //If not defined, use default comparison
             if (!compareFunc) {
                 compareFunc = function (a, b) {
                     return a == b;

--- a/jquery.jtable.js
+++ b/jquery.jtable.js
@@ -1429,11 +1429,11 @@ THE SOFTWARE.
             }
         },
 
-        /* Finds index of an element in an array according to given comparision function
+        /* Finds index of an element in an array according to given comparison function
         *************************************************************************/
         _findIndexInArray: function (value, array, compareFunc) {
 
-            //If not defined, use default comparision
+            //If not defined, use default comparison
             if (!compareFunc) {
                 compareFunc = function (a, b) {
                     return a == b;


### PR DESCRIPTION
There is a small typo in dev/jquery.jtable.utils.js, jquery.jtable.js.

Should read `comparison` rather than `comparision`.

